### PR TITLE
use admin route for audit table link

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     },
     "require": {
         "php": "^7.3",
-        "ezsystems/ezpublish-kernel": "^1.0",
+        "ezsystems/ezplatform-kernel": "^1.0",
+        "ezsystems/ezplatform-admin-ui": "^2.0",
         "doctrine/orm": "^2.6"
     }
 }

--- a/src/bundle/Resources/translations/messages.en.yml
+++ b/src/bundle/Resources/translations/messages.en.yml
@@ -3,9 +3,8 @@ activities:
         # Desc: Activities Log
         view: 'Activities Log'
 
-        content:
-            # Desc: Content ID
-            id: 'Content ID'
+        # Desc: Content
+        content: 'Content'
 
         event:
             # Desc: Event Data

--- a/src/bundle/Resources/views/themes/admin/activities/activitieslog_table.html.twig
+++ b/src/bundle/Resources/views/themes/admin/activities/activitieslog_table.html.twig
@@ -11,7 +11,7 @@
     <table class="table">
         <thead>
         <tr>
-            <th class="ez-table__header-cell">{{ 'activities.log.content.id'|trans|desc('Content ID') }}</th>
+            <th class="ez-table__header-cell">{{ 'activities.log.content'|trans|desc('Content') }}</th>
             <th class="ez-table__header-cell">{{ 'activities.log.user'|trans|desc('User') }}</th>
             <th class="ez-table__header-cell">{{ 'activities.log.event.name'|trans|desc('Event Name') }}</th>
             <th class="ez-table__header-cell">{{ 'activities.log.event.data'|trans|desc('Event Data') }}</th>
@@ -25,7 +25,7 @@
                     {% if log.contentObjectId is not null %}
                         {% set content = get_content(log.contentObjectId) %}
                         {% if content is not null and content.versionInfo.contentInfo.status == 1%}
-                            <a href="{{ path( "ez_urlalias", {"contentId": log.contentObjectId} ) }}">{{ ez_content_name(content) }}</a>
+                            <a href="{{ path( "_ez_content_view", {"contentId": log.contentObjectId} ) }}">{{ ez_content_name(content) }}</a>
                         {% else %}
                             {{ 'activities.log.user.not.found'|trans|desc('Not Found') }}: {{ log.contentObjectId }}
                         {% endif %}


### PR DESCRIPTION
- in some cases, URL alias will not work in admin interface, so it's preferred to use the admin route. 
- added admin UI requirement to `composer.json`
- fixed "Content" column name in admin UI

ps. cool bundle, thanks