### PR TITLE
fix translations usage

### DIFF
--- a/src/bundle/Resources/views/themes/admin/activities/activitieslog_interactive_login.html.twig
+++ b/src/bundle/Resources/views/themes/admin/activities/activitieslog_interactive_login.html.twig
@@ -1,7 +1,7 @@
 {% if userInteractiveLoginData is defined %}
     <div class="ez-table-header mt-3">
         <div class="ez-table-header__headline">
-            {{ 'Activities.log.login_history'|trans|desc('Login History') }}
+            {{ 'activities.log.login_history'|trans|desc('Login History') }}
         </div>
     </div>
 
@@ -10,31 +10,31 @@
             <tbody>
             <tr>
                 <th scope="row">
-                    {{ 'Activities.log.total_login'|trans|desc('Total login') }}
+                    {{ 'activities.log.total_login'|trans|desc('Total login') }}
                 </th>
                 <td>{{userInteractiveLoginData.loginNumber}}</td>
             </tr>
             <tr>
                 <th scope="row">
-                    {{ 'Activities.log.last_login_date'|trans|desc('Last login date') }}
+                    {{ 'activities.log.last_login_date'|trans|desc('Last login date') }}
                 </th>
                 <td>{{userInteractiveLoginData.lastLogin.date|ez_short_datetime}}</td>
             </tr>
             <tr>
                 <th scope="row">
-                    {{ 'Activities.log.password_expired'|trans|desc('Password expired') }}
+                    {{ 'activities.log.password_expired'|trans|desc('Password expired') }}
                 </th>
                 <td>
                     {% if userInteractiveLoginData.passwordExpired %}
-                        {{ 'Activities.log.yes'|trans|desc('Yes') }}
+                        {{ 'activities.log.yes'|trans|desc('Yes') }}
                     {% else %}
-                        {{ 'Activities.log.no'|trans|desc('No') }}
+                        {{ 'activities.log.no'|trans|desc('No') }}
                     {% endif %}
                 </td>
             </tr>
             <tr>
                 <th scope="row">
-                    {{ 'Activities.log.password_expiration_date'|trans|desc('Expiration Date') }}
+                    {{ 'activities.log.password_expiration_date'|trans|desc('Expiration Date') }}
                 </th>
                 <td>
                     {% if userInteractiveLoginData.passwordExpirationDate %}
@@ -49,7 +49,7 @@
                             })|desc('Current password <b>expires today</b>')|raw }}
                         {% endif %}
                     {% else %}
-                        {{ 'Activities.log.no'|trans|desc('No') }}
+                        {{ 'activities.log.no'|trans|desc('No') }}
                     {% endif %}
                 </td>
             </tr>

--- a/src/bundle/Resources/views/themes/admin/activities/activitieslog_table.html.twig
+++ b/src/bundle/Resources/views/themes/admin/activities/activitieslog_table.html.twig
@@ -2,7 +2,7 @@
 
 <div class="ez-table-header mt-3">
     <div class="ez-table-header__headline">
-        {{ 'Activities.log.view'|trans|desc('Activities Log') }}
+        {{ 'activities.log.view'|trans|desc('Activities Log') }}
         ({{ pagination.count }})
     </div>
 </div>


### PR DESCRIPTION
Fixing typo to properly display labels here:
![Screenshot from 2020-05-11 13-03-32](https://user-images.githubusercontent.com/2779573/81549774-f2b46c80-9387-11ea-86de-05006abb5f44.png)
